### PR TITLE
feat: add GitHub CLI installation and configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
 
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
 
     - name: Run Playbook
       run: |
-        ansible-playbook -i inventory.yml playbook.yml --extra-vars "github_token=$GH_TOKEN"
+        ansible-playbook -i inventory.yml playbook.yml --extra-vars "github_token=${{ github.token }}"
 
     - name: Verify Git Installation
       run: |
@@ -46,7 +46,7 @@ jobs:
 
     - name: Verify GitHub CLI Installation and Auth
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         gh --version
         gh auth status 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     steps:
     - uses: actions/checkout@v4
@@ -32,10 +34,8 @@ jobs:
         pip install ansible
 
     - name: Run Playbook
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
-        echo "$GH_TOKEN" | ansible-playbook -i inventory.yml playbook.yml --extra-vars "github_token=$GH_TOKEN"
+        ansible-playbook -i inventory.yml playbook.yml --extra-vars "github_token=$GH_TOKEN"
 
     - name: Verify Git Installation
       run: |
@@ -44,7 +44,9 @@ jobs:
           which git
         fi
 
-    - name: Verify GitHub CLI Installation
+    - name: Verify GitHub CLI Installation and Auth
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
         gh --version
         gh auth status 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,19 @@ jobs:
         pip install ansible
 
     - name: Run Playbook
-      run: ansible-playbook -i inventory.yml playbook.yml
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      run: |
+        echo "$GH_TOKEN" | ansible-playbook -i inventory.yml playbook.yml --extra-vars "github_token=$GH_TOKEN"
 
     - name: Verify Git Installation
       run: |
         git --version
         if [ "${{ runner.os }}" == "macOS" ]; then
           which git
-        fi 
+        fi
+
+    - name: Verify GitHub CLI Installation
+      run: |
+        gh --version
+        gh auth status 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ The playbook automates the installation and configuration of development tools a
   - Installs Git via Homebrew if not present
   - Provides status information about the installed Git version
 
+- GitHub CLI installation:
+  - Installs GitHub CLI (gh) via Homebrew on macOS
+  - Installs GitHub CLI via apt on Ubuntu
+  - Provides installation status and authentication instructions
+
 ## Repository Structure
 
 ```

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,12 @@
 ---
 - name: Minimal Ansible Playbook
   hosts: all
+  vars_prompt:
+    - name: github_token
+      prompt: "Enter your GitHub Personal Access Token (classic) with 'repo', 'read:org' scopes (press Enter to skip if already configured)"
+      private: yes
+      default: ""
+
   tasks:
     - name: Get Git version info
       command: git --version
@@ -101,12 +107,49 @@
       when: ansible_os_family == "Debian" and gh_version.rc != 0
       become: true
 
+    - name: Check GitHub CLI auth status
+      command: gh auth status
+      register: gh_auth_status
+      changed_when: false
+      ignore_errors: true
+
+    - name: Configure GitHub CLI
+      block:
+        - name: Set up GitHub CLI authentication
+          shell: |
+            echo "{{ github_token }}" | gh auth login --with-token
+          when: github_token != ""
+
+        - name: Configure git protocol preference
+          command: gh config set git_protocol ssh
+
+        - name: Configure default editor
+          command: gh config set editor "code --wait"
+
+        - name: Configure default browser
+          command: gh config set browser default
+
+        - name: Configure aliases
+          command: "{{ item }}"
+          loop:
+            - gh alias set prc 'pr create --web' --clobber
+            - gh alias set prv 'pr view --web' --clobber
+            - gh alias set prl 'pr list --web' --clobber
+            - gh alias set rv 'repo view --web' --clobber
+          ignore_errors: true
+      when: gh_auth_status.rc != 0
+
     - name: Show GitHub CLI status
       debug:
         msg: |
           GitHub CLI status:
           {% if gh_version.rc == 0 %}
           Version: {{ gh_version.stdout }}
+          {% if gh_auth_status.rc == 0 %}
+          Authentication: Configured
           {% else %}
-          GitHub CLI has been installed. Please run 'gh auth login' to authenticate.
+          Authentication: Not configured (token required)
+          {% endif %}
+          {% else %}
+          GitHub CLI has been installed and configured.
           {% endif %} 

--- a/playbook.yml
+++ b/playbook.yml
@@ -58,4 +58,55 @@
 
     - name: Example task
       debug:
-        msg: "Hello from Ansible!" 
+        msg: "Hello from Ansible!"
+
+    - name: Check if GitHub CLI is installed
+      command: gh --version
+      register: gh_version
+      changed_when: false
+      ignore_errors: true
+
+    - name: Install GitHub CLI on macOS
+      homebrew:
+        name: gh
+        state: latest
+      when: ansible_os_family == "Darwin" and gh_version.rc != 0
+
+    - name: Install GitHub CLI on Ubuntu
+      block:
+        - name: Install required packages
+          apt:
+            name: 
+              - curl
+              - gpg
+            state: present
+            
+        - name: Download GitHub CLI GPG key
+          get_url:
+            url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+            dest: /usr/share/keyrings/githubcli-archive-keyring.gpg
+            mode: '0644'
+
+        - name: Add GitHub CLI apt repository
+          apt_repository:
+            repo: deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
+            state: present
+            filename: github-cli
+
+        - name: Install GitHub CLI
+          apt:
+            name: gh
+            state: latest
+            update_cache: yes
+      when: ansible_os_family == "Debian" and gh_version.rc != 0
+      become: true
+
+    - name: Show GitHub CLI status
+      debug:
+        msg: |
+          GitHub CLI status:
+          {% if gh_version.rc == 0 %}
+          Version: {{ gh_version.stdout }}
+          {% else %}
+          GitHub CLI has been installed. Please run 'gh auth login' to authenticate.
+          {% endif %} 

--- a/playbook.yml
+++ b/playbook.yml
@@ -132,11 +132,32 @@
         - name: Configure aliases
           command: "{{ item }}"
           loop:
-            - gh alias set prc 'pr create --web' --clobber
+            - gh alias set prc 'pr create --web --assignee @me' --clobber
             - gh alias set prv 'pr view --web' --clobber
             - gh alias set prl 'pr list --web' --clobber
             - gh alias set rv 'repo view --web' --clobber
           ignore_errors: true
+
+        - name: Add PR template
+          copy:
+            dest: ~/.config/gh/pr-template.md
+            content: |
+              # Pull Request
+
+              ## Changes
+              {% raw %}
+              {{.Message}}
+              {% endraw %}
+
+              ## Checklist
+              - [ ] Tests passing
+              - [ ] Documentation updated
+              - [ ] Code follows project standards
+            mode: '0644'
+            force: yes
+
+        - name: Configure PR template
+          command: gh config set pr.template ~/.config/gh/pr-template.md
 
     - name: Show GitHub CLI status
       debug:

--- a/playbook.yml
+++ b/playbook.yml
@@ -148,11 +148,6 @@
               {% raw %}
               {{.Message}}
               {% endraw %}
-
-              ## Checklist
-              - [ ] Tests passing
-              - [ ] Documentation updated
-              - [ ] Code follows project standards
             mode: '0644'
             force: yes
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -113,13 +113,13 @@
       changed_when: false
       ignore_errors: true
 
-    - name: Configure GitHub CLI
-      block:
-        - name: Set up GitHub CLI authentication
-          shell: |
-            echo "{{ github_token }}" | gh auth login --with-token
-          when: github_token != ""
+    - name: Configure GitHub CLI authentication
+      shell: |
+        echo "{{ github_token }}" | gh auth login --with-token
+      when: github_token != "" and gh_auth_status.rc != 0
 
+    - name: Configure GitHub CLI settings
+      block:
         - name: Configure git protocol preference
           command: gh config set git_protocol ssh
 
@@ -137,7 +137,6 @@
             - gh alias set prl 'pr list --web' --clobber
             - gh alias set rv 'repo view --web' --clobber
           ignore_errors: true
-      when: gh_auth_status.rc != 0
 
     - name: Show GitHub CLI status
       debug:


### PR DESCRIPTION
- Add GitHub CLI installation via package managers (Homebrew/apt)
- Add CLI configuration (auth, preferences)
- Add useful aliases with clobber flag
- Add GitHub token to CI workflow