### PR TITLE
feat: add Zsh configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,9 @@ jobs:
     - name: Verify GitHub CLI Installation and Auth
       run: |
         gh --version
-        gh auth status 
+        gh auth status
+
+    - name: Verify Zsh Installation
+      run: |
+        zsh --version
+        which zsh 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,4 +64,5 @@ jobs:
           cat ~/.oh-my-zsh/oh-my-zsh.sh | head -n 1
         else
           echo "Oh My Zsh is not installed"
-          exit 1 
+          exit 1
+        fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,4 +55,13 @@ jobs:
     - name: Verify Zsh Installation
       run: |
         zsh --version
-        which zsh 
+        which zsh
+
+    - name: Verify Oh My Zsh Installation
+      run: |
+        if [ -d ~/.oh-my-zsh ]; then
+          echo "Oh My Zsh is installed"
+          cat ~/.oh-my-zsh/oh-my-zsh.sh | head -n 1
+        else
+          echo "Oh My Zsh is not installed"
+          exit 1 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DevEnv Ansible Playbook
 
-This repository contains an Ansible playbook for setting up and maintaining a consistent development environment across macOS and Ubuntu systems.
+This repository contains an [Ansible](https://www.ansible.com/) playbook for setting up and maintaining a consistent development environment across [macOS](https://www.apple.com/macos/) and [Ubuntu](https://ubuntu.com/) systems.
 
 ## Purpose
 
@@ -8,19 +8,19 @@ The playbook automates the installation and configuration of development tools a
 
 ## Current Features
 
-- Git installation and management:
+- [Git](https://git-scm.com/) installation and management:
   - Updates Apple Git via Xcode Command Line Tools on macOS
-  - Installs Git via Homebrew if not present
+  - Installs Git via [Homebrew](https://brew.sh/) if not present
   - Provides status information about the installed Git version
 
 - GitHub CLI installation:
-  - Installs GitHub CLI (gh) via Homebrew on macOS
+  - Installs [GitHub CLI](https://cli.github.com/) (gh) via Homebrew on macOS
   - Installs GitHub CLI via apt on Ubuntu
   - Provides installation status and authentication instructions
 
-- Zsh configuration:
+- [Zsh](https://www.zsh.org/) configuration:
   - Installs Zsh if not present
-  - Installs and configures Oh My Zsh
+  - Installs and configures [Oh My Zsh](https://ohmyz.sh/)
   - Sets up common plugins (git, gh, docker, kubectl, etc.)
   - Configures custom aliases for common commands
   - Sets Zsh as the default shell
@@ -29,24 +29,36 @@ The playbook automates the installation and configuration of development tools a
 
 ```
 .
-├── .github/workflows/   # GitHub Actions workflow configurations
-├── inventory.yml       # Ansible inventory file
-└── playbook.yml       # Main Ansible playbook
+├── .github/
+│   └── workflows/       # GitHub Actions workflow configurations
+├── roles/
+│   └── common/          # Common role for shared functionality
+│       ├── defaults/    # Default variables for the role
+│       ├── files/       # Static files used by the role
+│       ├── handlers/    # Handlers for the role
+│       ├── meta/        # Role metadata
+│       ├── tasks/       # Tasks for the role
+│       ├── templates/   # Jinja2 templates
+│       └── vars/        # Role variables
+├── .editorconfig        # Editor configuration
+├── .gitignore           # Git ignore rules
+├── inventory.yml        # Ansible inventory file
+└── playbook.yml         # Main Ansible playbook
 ```
 
 ## CI/CD
 
 The repository uses GitHub Actions to test the playbook on both Ubuntu and macOS environments. Tests run on:
-- Every push to master
-- Every push to feature branches (feat/**)
-- Pull requests targeting master or feature branches
+- Every push to `master`
+- Every push to feature branches (`feat/**`)
+- Pull requests targeting `master` or feature branches
 
 ## For AI Agents
 
 This repository is AI-friendly and follows these conventions:
 
 ### Commit Messages
-- Uses semantic commit messages (feat:, fix:, ci:, etc.)
+- Uses semantic commit messages (`feat:`, `fix:`, `ci:`, etc.)
 - Each commit message has a clear title and description
 - Descriptions use bullet points for multiple items
 - Add `[skip CI]` to commit messages on commits that only changed the documentation
@@ -60,7 +72,7 @@ This repository is AI-friendly and follows these conventions:
 1. Create a feature branch from master
 2. Make changes and test locally
 3. Push changes and create a PR
-4. Merge to master after CI passes
+4. After the PR gets merged on GitHub, delete the local branch and update `master`
 
 ## Getting Started
 
@@ -81,13 +93,6 @@ export GH_TOKEN='your_github_token'
 # User information for GPG key generation
 export USER_NAME='Your Name'
 export USER_EMAIL='your.email@example.com'
-```
-
-Then you can run it without any prompt <3
-
-```bash
-# Run the playbook
-ansible-playbook -i inventory.yml playbook.yml
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ The playbook automates the installation and configuration of development tools a
   - Installs GitHub CLI via apt on Ubuntu
   - Provides installation status and authentication instructions
 
+- Zsh configuration:
+  - Installs Zsh if not present
+  - Installs and configures Oh My Zsh
+  - Sets up common plugins (git, gh, docker, kubectl, etc.)
+  - Configures custom aliases for common commands
+  - Sets Zsh as the default shell
+
 ## Repository Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ To run the playbook locally:
 ansible-playbook -i inventory.yml playbook.yml
 ```
 
+## Local Testing
+
+You can set the following environment variables to avoid being prompted during playbook execution:
+
+```bash
+# GitHub Personal Access Token with required scopes
+export GH_TOKEN='your_github_token'
+
+# User information for GPG key generation
+export USER_NAME='Your Name'
+export USER_EMAIL='your.email@example.com'
+```
+
+Then you can run it without any prompt <3
+
+```bash
+# Run the playbook
+ansible-playbook -i inventory.yml playbook.yml
+```
+
 ## Requirements
 
 - Python 3.x

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repository is AI-friendly and follows these conventions:
 - Uses semantic commit messages (feat:, fix:, ci:, etc.)
 - Each commit message has a clear title and description
 - Descriptions use bullet points for multiple items
+- Add `[skip CI]` to commit messages on commits that only changed the documentation
 
 ### Branch Strategy
 - Main branch: `master`

--- a/playbook.yml
+++ b/playbook.yml
@@ -309,7 +309,7 @@
         create: yes
       when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
       register: plugins_config
-      failed_when: plugins_config.rc != 0
+      failed_when: not plugins_config.changed and not plugins_config.found
 
     - name: Configure Oh My Zsh theme
       lineinfile:
@@ -319,7 +319,7 @@
         create: yes
       when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
       register: theme_config
-      failed_when: theme_config.rc != 0
+      failed_when: not theme_config.changed and not theme_config.found
 
     - name: Add custom aliases
       blockinfile:
@@ -331,7 +331,7 @@
         create: yes
       when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
       register: aliases_config
-      failed_when: aliases_config.rc != 0
+      failed_when: not aliases_config.changed and not aliases_config.found
 
     - name: Set Zsh as default shell
       shell: chsh -s $(which zsh)

--- a/playbook.yml
+++ b/playbook.yml
@@ -277,6 +277,8 @@
         name: zsh
         state: latest
       when: ansible_os_family == "Darwin" and zsh_version.rc != 0
+      register: zsh_install
+      failed_when: zsh_install.rc != 0
 
     - name: Install Zsh on Ubuntu
       apt:
@@ -284,6 +286,8 @@
         state: latest
       when: ansible_os_family == "Debian" and zsh_version.rc != 0
       become: true
+      register: zsh_install
+      failed_when: zsh_install.rc != 0
 
     - name: Check if Oh My Zsh is installed
       stat:
@@ -294,6 +298,8 @@
       shell: |
         sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
       when: not oh_my_zsh.stat.exists
+      register: oh_my_zsh_install
+      failed_when: oh_my_zsh_install.rc != 0
 
     - name: Configure Oh My Zsh plugins
       lineinfile:
@@ -301,7 +307,9 @@
         regexp: '^plugins=\(.*\)$'
         line: 'plugins=(git gh docker docker-compose kubectl helm aws terraform)'
         create: yes
-      when: oh_my_zsh.stat.exists
+      when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
+      register: plugins_config
+      failed_when: plugins_config.rc != 0
 
     - name: Configure Oh My Zsh theme
       lineinfile:
@@ -309,7 +317,9 @@
         regexp: '^ZSH_THEME=.*$'
         line: 'ZSH_THEME="robbyrussell"'
         create: yes
-      when: oh_my_zsh.stat.exists
+      when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
+      register: theme_config
+      failed_when: theme_config.rc != 0
 
     - name: Add custom aliases
       blockinfile:
@@ -317,13 +327,18 @@
         block: |
           # Custom aliases
           alias ll='ls -la'
+          alias k='kubectl'
         create: yes
-      when: oh_my_zsh.stat.exists
+      when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
+      register: aliases_config
+      failed_when: aliases_config.rc != 0
 
     - name: Set Zsh as default shell
       shell: chsh -s $(which zsh)
       when: zsh_version.rc == 0 and ansible_env.SHELL != '/bin/zsh'
       become: true
+      register: chsh_config
+      failed_when: chsh_config.rc != 0
       ignore_errors: true
 
     - name: Show Zsh status
@@ -332,7 +347,7 @@
           Zsh status:
           {% if zsh_version.rc == 0 %}
           Version: {{ zsh_version.stdout }}
-          {% if oh_my_zsh.stat.exists %}
+          {% if oh_my_zsh.stat.exists or (oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0) %}
           Oh My Zsh: Installed
           {% else %}
           Oh My Zsh: Not installed

--- a/playbook.yml
+++ b/playbook.yml
@@ -309,7 +309,7 @@
         create: yes
       when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
       register: plugins_config
-      failed_when: not plugins_config.changed and not plugins_config.found
+      failed_when: plugins_config.failed
 
     - name: Configure Oh My Zsh theme
       lineinfile:
@@ -319,19 +319,19 @@
         create: yes
       when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
       register: theme_config
-      failed_when: not theme_config.changed and not theme_config.found
+      failed_when: theme_config.failed
 
-    - name: Add custom aliases
-      blockinfile:
-        path: ~/.zshrc
-        block: |
+    - name: Create custom aliases file
+      copy:
+        dest: ~/.oh-my-zsh/custom/aliases.zsh
+        content: |
           # Custom aliases
           alias ll='ls -la'
           alias k='kubectl'
-        create: yes
+        mode: '0644'
       when: oh_my_zsh.stat.exists or oh_my_zsh_install is defined and oh_my_zsh_install.rc == 0
       register: aliases_config
-      failed_when: not aliases_config.changed and not aliases_config.found
+      failed_when: aliases_config.failed
 
     - name: Set Zsh as default shell
       shell: chsh -s $(which zsh)

--- a/playbook.yml
+++ b/playbook.yml
@@ -278,7 +278,7 @@
         state: latest
       when: ansible_os_family == "Darwin" and zsh_version.rc != 0
       register: zsh_install
-      failed_when: zsh_install.rc != 0
+      failed_when: zsh_install.failed
 
     - name: Install Zsh on Ubuntu
       apt:
@@ -287,7 +287,7 @@
       when: ansible_os_family == "Debian" and zsh_version.rc != 0
       become: true
       register: zsh_install
-      failed_when: zsh_install.rc != 0
+      failed_when: zsh_install.failed
 
     - name: Check if Oh My Zsh is installed
       stat:
@@ -299,7 +299,7 @@
         sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
       when: not oh_my_zsh.stat.exists
       register: oh_my_zsh_install
-      failed_when: oh_my_zsh_install.rc != 0
+      failed_when: oh_my_zsh_install.failed
 
     - name: Configure Oh My Zsh plugins
       lineinfile:

--- a/playbook.yml
+++ b/playbook.yml
@@ -264,4 +264,79 @@
           {% endif %}
           {% else %}
           GitHub CLI has been installed and configured.
+          {% endif %}
+
+    - name: Check if Zsh is installed
+      command: zsh --version
+      register: zsh_version
+      changed_when: false
+      ignore_errors: true
+
+    - name: Install Zsh on macOS
+      homebrew:
+        name: zsh
+        state: latest
+      when: ansible_os_family == "Darwin" and zsh_version.rc != 0
+
+    - name: Install Zsh on Ubuntu
+      apt:
+        name: zsh
+        state: latest
+      when: ansible_os_family == "Debian" and zsh_version.rc != 0
+      become: true
+
+    - name: Check if Oh My Zsh is installed
+      stat:
+        path: ~/.oh-my-zsh
+      register: oh_my_zsh
+
+    - name: Install Oh My Zsh
+      shell: |
+        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+      when: not oh_my_zsh.stat.exists
+
+    - name: Configure Oh My Zsh plugins
+      lineinfile:
+        path: ~/.zshrc
+        regexp: '^plugins=\(.*\)$'
+        line: 'plugins=(git gh docker docker-compose kubectl helm aws terraform)'
+        create: yes
+      when: oh_my_zsh.stat.exists
+
+    - name: Configure Oh My Zsh theme
+      lineinfile:
+        path: ~/.zshrc
+        regexp: '^ZSH_THEME=.*$'
+        line: 'ZSH_THEME="robbyrussell"'
+        create: yes
+      when: oh_my_zsh.stat.exists
+
+    - name: Add custom aliases
+      blockinfile:
+        path: ~/.zshrc
+        block: |
+          # Custom aliases
+          alias ll='ls -la'
+        create: yes
+      when: oh_my_zsh.stat.exists
+
+    - name: Set Zsh as default shell
+      shell: chsh -s $(which zsh)
+      when: zsh_version.rc == 0 and ansible_env.SHELL != '/bin/zsh'
+      become: true
+      ignore_errors: true
+
+    - name: Show Zsh status
+      debug:
+        msg: |
+          Zsh status:
+          {% if zsh_version.rc == 0 %}
+          Version: {{ zsh_version.stdout }}
+          {% if oh_my_zsh.stat.exists %}
+          Oh My Zsh: Installed
+          {% else %}
+          Oh My Zsh: Not installed
+          {% endif %}
+          {% else %}
+          Zsh is not installed
           {% endif %} 


### PR DESCRIPTION
This PR adds Zsh configuration to the playbook:

- Install Zsh if not present
- Install and configure Oh My Zsh
- Set up common plugins (git, gh, docker, kubectl, etc.)
- Configure custom aliases
- Set Zsh as the default shell