### PR TITLE
feat: add JetBrains Mono font installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,16 @@ jobs:
         gh --version
         gh auth status
 
+    - name: Verify JetBrains Mono Font Installation
+      if: runner.os == 'macOS'
+      run: |
+        if [ -f "$HOME/Library/Fonts/JetBrainsMono-Regular.ttf" ]; then
+          echo "JetBrains Mono font is installed"
+        else
+          echo "JetBrains Mono font is not installed"
+          exit 1
+        fi
+
     - name: Verify Zsh Installation
       run: |
         zsh --version

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The playbook automates the installation and configuration of development tools a
   - Configures custom aliases for common commands
   - Sets Zsh as the default shell
 
+- Font installation:
+  - Installs [JetBrains Mono](https://www.jetbrains.com/lp/mono/) font on macOS
+  - Provides a clean, modern monospace font optimized for coding
+
 ## Repository Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ To run the playbook locally:
 ansible-playbook -i inventory.yml playbook.yml
 ```
 
+You can also [use tags](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tags.html) to run only parts of the playbook.
+
+```bash
+ansible-playbook -i inventory.yml playbook.yml --tags [TAG]
+```
+
+### Tag List
+
+Here is a list with all the tags that we have in this playbook.
+
+| Tag | Description |
+|-----|-------------|
+| `fonts` | Installs and configures JetBrains Mono font (macOS only) |
+
 ## Local Testing
 
 You can set the following environment variables to avoid being prompted during playbook execution:

--- a/playbook.yml
+++ b/playbook.yml
@@ -354,4 +354,8 @@
           {% endif %}
           {% else %}
           Zsh is not installed
-          {% endif %} 
+          {% endif %}
+
+    - name: Install JetBrains Mono font
+      include_tasks: roles/common/tasks/fonts.yml
+      tags: fonts

--- a/roles/common/tasks/fonts.yml
+++ b/roles/common/tasks/fonts.yml
@@ -1,0 +1,51 @@
+---
+# Install JetBrains Mono font on macOS
+- name: Create fonts directory if it doesn't exist
+  file:
+    path: "{{ ansible_user_dir }}/Library/Fonts"
+    state: directory
+    mode: '0755'
+  when: ansible_os_family == "Darwin"
+  tags: fonts
+
+- name: Download JetBrains Mono font
+  get_url:
+    url: https://download.jetbrains.com/fonts/JetBrainsMono-2.304.zip
+    dest: "{{ ansible_user_dir }}/Downloads/JetBrainsMono.zip"
+    mode: '0644'
+  when: ansible_os_family == "Darwin"
+  tags: fonts
+
+- name: Create JetBrains Mono directory
+  file:
+    path: "{{ ansible_user_dir }}/Downloads/JetBrainsMono"
+    state: directory
+    mode: '0755'
+  when: ansible_os_family == "Darwin"
+  tags: fonts
+
+- name: Unzip JetBrains Mono font
+  unarchive:
+    src: "{{ ansible_user_dir }}/Downloads/JetBrainsMono.zip"
+    dest: "{{ ansible_user_dir }}/Downloads/JetBrainsMono"
+    remote_src: yes
+  when: ansible_os_family == "Darwin"
+  tags: fonts
+
+- name: Install JetBrains Mono font
+  shell: |
+    find "{{ ansible_user_dir }}/Downloads/JetBrainsMono/fonts/ttf" -name "*.ttf" -exec cp {} "{{ ansible_user_dir }}/Library/Fonts/" \;
+  args:
+    creates: "{{ ansible_user_dir }}/Library/Fonts/JetBrainsMono-Regular.ttf"
+  when: ansible_os_family == "Darwin"
+  tags: fonts
+
+- name: Clean up downloaded files
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ ansible_user_dir }}/Downloads/JetBrainsMono.zip"
+    - "{{ ansible_user_dir }}/Downloads/JetBrainsMono"
+  when: ansible_os_family == "Darwin"
+  tags: fonts 


### PR DESCRIPTION
This PR adds support for installing JetBrains Mono font on macOS systems. Changes include:

- New task file for font installation
- CI test to verify font installation
- Documentation updates
- The font will be installed in the user's Fonts directory and can be used in any code editor.