### PR TITLE
fix: configure GPG signing for commits and tags

### DIFF
--- a/roles/common/tasks/gpg.yml
+++ b/roles/common/tasks/gpg.yml
@@ -69,8 +69,11 @@
 - name: Configure Git to use GPG key
   command: "{{ item }}"
   loop:
+    - git config --global user.name "{{ user_name }}"
+    - git config --global user.email "{{ user_email }}"
     - git config --global user.signingkey {{ gpg_key_id.stdout }}
     - git config --global commit.gpgsign true
+    - git config --global tag.gpgsign true
   when: gpg_key_id.stdout != ""
   tags: [gpg]
 


### PR DESCRIPTION
This PR configures GPG signing for both commits and tags to ensure all changes are properly verified.